### PR TITLE
-w option wide output for hosts and services view

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,7 +111,7 @@ Output example:
 ```
 $ naginata services -a
 NAGIOS   HOST                 SERVICE          STATUS   FLAGS  OUTPUT
-nagios0  localhost            HTTP             WARNING  AC,nt  HTTP WARNING: HTTP/1.1 403 Forbidden - 5152 bytes in 0.001 second response time
+nagios0  localhost            HTTP             WARNING  AC,nt  HTTP WARNING: HTTP/1.1 403 Forbidden - 5152 bytes ...
 nagios0  localhost            Current Load     OK       AC,NT  OK - load average: 0.00, 0.00, 0.00
 nagios0  localhost            PING             OK       AC,NT  PING OK - Packet loss = 0%, RTA = 0.04 ms
 nagios0  redis01.tokyo.local  Load             CRITICAL AC,NT  Too high load average 15

--- a/lib/naginata/cli.rb
+++ b/lib/naginata/cli.rb
@@ -44,6 +44,7 @@ module Naginata
     desc 'hosts [hostpattern ..]', 'View host status'
     method_option :nagios, desc: "Filter hosts by nagios server names", type: :array
     method_option :all_hosts, aliases: "-a", desc: "Target all hosts", type: :boolean
+    method_option :wide, aliases: "-w", desc: "Wide output", type: :boolean
     def hosts(*patterns)
       if patterns.empty? and !options[:all_hosts]
         help(:hosts)
@@ -57,6 +58,7 @@ module Naginata
     method_option :nagios, desc: "Filter hosts by nagios server names", type: :array
     method_option :services, aliases: "-s", desc: "Filter by service description", type: :array
     method_option :all_hosts, aliases: "-a", desc: "Target all hosts", type: :boolean
+    method_option :wide, aliases: "-w", desc: "Wide output", type: :boolean
     def services(*patterns)
       if patterns.empty? and !options[:all_hosts]
         help(:services)

--- a/lib/naginata/cli/hosts.rb
+++ b/lib/naginata/cli/hosts.rb
@@ -24,7 +24,7 @@ module Naginata
         }
         table.concat(status.decorate.hosts_table)
       end
-      Naginata.ui.print_table table
+      Naginata.ui.print_table(table, truncate: !@options[:wide])
     end
 
   end

--- a/lib/naginata/cli/services.rb
+++ b/lib/naginata/cli/services.rb
@@ -31,7 +31,7 @@ module Naginata
         }
         table.concat(status.decorate.services_table)
       end
-      Naginata.ui.print_table table
+      Naginata.ui.print_table(table, truncate: !@options[:wide])
     end
 
   end

--- a/spec/commands/hosts_spec.rb
+++ b/spec/commands/hosts_spec.rb
@@ -47,6 +47,15 @@ describe 'naginata hosts' do
     end
   end
 
+  describe 'with --wide option' do
+    before { naginata :hosts, all_hosts: true, wide: true }
+    it "prints table" do
+      expect(exitstatus).to eq 0
+      expect(err).to eq ''
+      expect(out).to  match /^NAGIOS\s+HOST\s+STATUS\s+FLAGS\s+OUTPUT$/
+    end
+  end
+
   describe 'with --nagios option' do
     before { naginata :hosts, all_hosts: true, nagios: "nagios001,nagios002.example.com"}
     it "prints table" do

--- a/spec/commands/services_spec.rb
+++ b/spec/commands/services_spec.rb
@@ -64,4 +64,13 @@ describe 'naginata services' do
     end
   end
 
+  describe 'with --wide option' do
+    before { naginata :services, all_hosts: true, wide: true}
+    it "prints table" do
+      expect(exitstatus).to eq 0
+      expect(err).to eq ''
+      expect(out).to  match /^NAGIOS\s+HOST\s+SERVICE\s+STATUS\s+FLAGS\s+OUTPUT$/
+    end
+  end
+
 end


### PR DESCRIPTION
Status view output's width can be too large width. This truncates table width to screen width by default. And -w option supports for full width view.