### PR TITLE
Filter nagios servers before loading cached status file

### DIFF
--- a/lib/naginata/loader.rb
+++ b/lib/naginata/loader.rb
@@ -18,13 +18,8 @@ module Naginata
         # Refresh cached status.dat
         CLI::Fetch.new(fetch_options).run
 
-        # Load status.dat
-        #
-        # @Note currently here reads all nagios servers' cache files. This
-        # means that users can not reduce nagios servers by --nagios= CLI 
-        # option. Below loop may be moved into initialization phase of CLI
-        # class.
-        Configuration.env.nagios_servers.each do |nagios_server|
+        nagios_servers = Configuration.env.filter(Configuration.env.nagios_servers)
+        nagios_servers.each do |nagios_server|
           status = ::Naginata::Status.find(nagios_server.hostname)
           status.service_items.group_by{ |section| section.host_name }.each do |host, sections|
             services = sections.map { |s| s.service_description }


### PR DESCRIPTION
Run time speeds up by this fix. Previously, all status files were loaded in memory even if users set nagios filters.